### PR TITLE
[pu-2.0] Rails Admin (2)

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,10 +1,25 @@
 # frozen_string_literal: true
 
-class ApplicationController < ActionController::Base
-  protect_from_forgery with: :exception unless -> { request.format.json? }
+class ApiController < ActionController::API
+  include Pundit
   before_action :set_locale
 
+  def status
+    render json: {}, status: :ok
+  end
+
+  rescue_from StandardError do |e|
+    @error = Mersea::Errors.format(e)
+    render json: @error, status: @error.status
+  end
+
   private
+
+  # Customize pundit's user
+  # https://github.com/varvet/pundit#additional-context
+  def pundit_user
+    UserContext.new(current_user, params)
+  end
 
   def default_url_options(options = {})
     return options if current_user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,26 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception unless -> { request.format.json? }
   before_action :set_locale
 
+  protected
+
+  # Compatible redirection with Rails API
+  def after_sign_in_path_for(resource)
+    if resource.is_a?(Admin)
+      rails_admin_path
+    else
+      super
+    end
+  end
+
+  # Compatible redirection with Rails API
+  def after_sign_out_path_for(resource)
+    if resource == :admin || resource.is_a?(Admin)
+      new_admin_session_path
+    else
+      super
+    end
+  end
+
   private
 
   def default_url_options(options = {})

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,4 @@
-class PagesController < ApplicationController
+class PagesController < ApiController
   def index
     @pages = Page.order(:name).all
     render json: @pages, status: :ok

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,4 +1,4 @@
-class ReportsController < ApplicationController
+class ReportsController < ApiController
   before_action :fetch_report, only: %i(show update destroy)
 
   def index

--- a/app/controllers/tracers_controller.rb
+++ b/app/controllers/tracers_controller.rb
@@ -1,4 +1,4 @@
-class TracersController < ApplicationController
+class TracersController < ApiController
   def index
     @tracers = Tracer.order(:name).all
     render json: @tracers, status: :ok

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,4 @@
-class UsersController < ApplicationController
+class UsersController < ApiController
   before_action :authenticate_user!
   before_action :authorize_user!, only: %i(me update update_password)
 

--- a/app/views/layouts/_menu.html.erb
+++ b/app/views/layouts/_menu.html.erb
@@ -23,6 +23,7 @@
         <span class="mm-menu__link-text <%= 'active' if request.path == leaderboard_path %>"><%= t('.leaderboard') %></span>
       <% end %>
     </li>
+    <% @pages = [] %> <!-- FIXME Cleanup assets & views for v2.0 -->
     <% @pages.each do |page| %>
       <li class="mm-menu__link">
         <%= link_to page_path(page), class: 'mm-menu__link' do %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,14 @@ Bundler.require(*Rails.groups)
 
 module Mersea
   class Application < Rails::Application
+    config.api_only = true
+
+    # ActiveAdmin compatibility
+    config.middleware.use Rack::MethodOverride
+    config.middleware.use ActionDispatch::Flash
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore
+
     config.eager_load_paths << Rails.root.join('lib')
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -221,7 +221,7 @@ Devise.setup do |config|
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
   # are using only default views.
-  # config.scoped_views = false
+  # config.scoped_views = true
 
   # Configure the default scope given to Warden. By default it's the first
   # devise role declared in your routes (usually :user).
@@ -264,7 +264,7 @@ Devise.setup do |config|
 
   config.jwt do |jwt|
     jwt.secret = Rails.application.secrets.jwt_secret
-    jwt.expiration_time = 1.week # FIXME reduce that value and use refresh token mechanism
+    jwt.expiration_time = 1.week
   end
 
   # ==> Mountable engine configurations

--- a/config/initializers/devise_failure.rb
+++ b/config/initializers/devise_failure.rb
@@ -1,7 +1,26 @@
 class CustomFailure < Devise::FailureApp
+  def redirect_url
+    new_admin_session_url if admin?
+  end
+
   def respond
-    self.status = :unauthorized
-    self.response_body = { errors: i18n_message }.to_json
-    self.content_type = 'application/json; charset=utf-8'
+    unless admin? # API Users
+      self.status = :unauthorized
+      self.response_body = { errors: i18n_message }.to_json
+      self.content_type = 'application/json; charset=utf-8'
+      return
+    end
+
+    if http_auth?
+      http_auth
+    else
+      redirect
+    end
+  end
+
+  private
+
+  def admin?
+    warden_options[:scope] == :admin
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,11 @@
 Rails.application.routes.draw do
   devise_for :admin
-  mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
   devise_for :users, controllers: {
     registrations: 'users/registrations',
     sessions: 'users/sessions',
     passwords: 'users/passwords'
   }
-  match '/status', to: 'application#status', via: %i(get head)
+  match '/status', to: 'api#status', via: %i(get head)
   root to: 'pages#index'
   resources :tracers, only: %i(index show)
   resources :reports, only: %i(index create show update destroy)
@@ -20,4 +19,6 @@ Rails.application.routes.draw do
     end
   end
   match '/leaderboard', to: 'pages#leaderboard', via: :get
+
+  mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
 end


### PR DESCRIPTION
- Create dedicated `ApiController`
- Rails Admin now works
- [x] Redirect `/admin/sign_in` to `/admin` after successful sign-in

The `views/layouts/*` should be refactored for the new UI.
Useless dependencies or code should be droped.