### PR TITLE
[pu-2.0] Cache /reports & /leaderboard with nginx

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -10,20 +10,12 @@ class PagesController < ApiController
   end
 
   def leaderboard
-    @leaderboard = Rails.cache.fetch('leaderboard')
-    fetch_leaderboard unless @leaderboard
-    render json: @leaderboard
-  end
-
-  private
-
-  def fetch_leaderboard
     users = User.joins(:reports).group('users.id').having('count(users.id) > 0')
     @leaderboard = users.map do |user|
       { name: user.name,
         reports_count: user.reports.count,
         last_activity: user.reports.last.reported_at }
-    end || []
-    Rails.cache.write('leaderboard', @leaderboard, expires_in: 12.hours) unless @leaderboard.empty?
+      end || []
+    render json: @leaderboard
   end
 end

--- a/dockerfiles/nginx.conf
+++ b/dockerfiles/nginx.conf
@@ -2,6 +2,9 @@ upstream app {
   server app-container:3000;
 }
 
+proxy_cache_path /tmp/leaderboard levels=1:2 keys_zone=leaderboard:10m inactive=12h max_size=256m;
+proxy_cache_path /tmp/reports levels=1:2 keys_zone=reports:10m inactive=1h max_size=256m;
+
 server {
   listen 80;
   server_name _;
@@ -12,6 +15,36 @@ server {
 
   location / {
     try_files $uri $uri/index.html @upstream;
+  }
+
+  location /leaderboard {
+    proxy_cache leaderboard;
+    proxy_cache_methods GET;
+    proxy_cache_valid 200 12h;
+    proxy_ignore_headers Cache-Control;
+    add_header X-Cache-Status $upstream_cache_status;
+
+    proxy_pass http://app;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
+
+  error_page 418 = @upstream;
+  location /reports {
+    if ( $arg_user_id != "" ) {
+      # Here we don't want to have cache when user is requesting its own reports.
+      # pretty ugly to use error_page to jump to `location @upstream` block..
+      return 418;
+    }
+    proxy_cache reports;
+    proxy_cache_methods GET;
+    proxy_cache_valid 200 1h;
+    proxy_ignore_headers Cache-Control;
+    add_header X-Cache-Status $upstream_cache_status;
+
+    proxy_pass http://app;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }
 
   location @upstream {


### PR DESCRIPTION
## How to?

- Edit the `dockerfiles/nginx.conf` with your @IP

```
upstream app {
  # server app-container:3000;
  server 192.168.1.101:3000;
}
```

- Start Rails server with global binding

```
bundle exec rails s -b 0.0.0.0 -p 3000
```

- Run nginx container

```
cd to/mersea
docker run -v $(pwd)/dockerfiles/nginx.conf:/etc/nginx/conf.d/default.conf:ro -p 8042:80 -it nginx:1.13-alpine
```

## How to check?

The Rails server will now not been reached when th cache is loaded

```sh
$ curl -v http://localhost:8042/leaderboard
...
< X-Cache-Status: MISS
...

$ curl -v http://localhost:8042/leaderboard
...
< X-Cache-Status: HIT
...
```

> MISS => nocache ; HIT => cache found