### PR TITLE
[pu-2.0] Fixed nginx cache

### DIFF
--- a/dockerfiles/nginx.conf
+++ b/dockerfiles/nginx.conf
@@ -2,8 +2,8 @@ upstream app {
   server app-container:3000;
 }
 
-proxy_cache_path /tmp/leaderboard levels=1:2 keys_zone=leaderboard:10m inactive=12h max_size=256m;
-proxy_cache_path /tmp/reports levels=1:2 keys_zone=reports:10m inactive=1h max_size=256m;
+proxy_cache_path /tmp/leaderboard levels=1:2 keys_zone=leaderboard:10m inactive=12h max_size=128m;
+proxy_cache_path /tmp/reports levels=1:2 keys_zone=reports:10m inactive=1h max_size=128m;
 
 server {
   listen 80;
@@ -17,7 +17,7 @@ server {
     try_files $uri $uri/index.html @upstream;
   }
 
-  location /leaderboard {
+  location = /leaderboard {
     proxy_cache leaderboard;
     proxy_cache_methods GET;
     proxy_cache_valid 200 12h;
@@ -29,14 +29,16 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }
 
-  error_page 418 = @upstream;
-  location /reports {
+  error_page 442 = @upstream;
+  location = /reports {
     if ( $arg_user_id != "" ) {
       # Here we don't want to have cache when user is requesting its own reports.
       # pretty ugly to use error_page to jump to `location @upstream` block..
-      return 418;
+      return 442;
     }
+
     proxy_cache reports;
+    proxy_cache_key $scheme$proxy_host$uri$http_accept$is_args$args;
     proxy_cache_methods GET;
     proxy_cache_valid 200 1h;
     proxy_ignore_headers Cache-Control;


### PR DESCRIPTION
Linked to #191

Add `Accept` header to the cache key to cache all render formats.