### PR TITLE
[pu-2.0] Slim geojson payload

### DIFF
--- a/app/serializers/geojson_report_serializer.rb
+++ b/app/serializers/geojson_report_serializer.rb
@@ -13,11 +13,7 @@ class GeojsonReportSerializer < ActiveModel::Serializer
       user: {
         name:  object.user&.name || object.name
       },
-      tracer: {
-        id: object.tracer_id,
-        name: object.tracer.name,
-        photo: photo_url
-      },
+      tracer_id: object.tracer_id,
       color: object.tracer.color,
       quantity: object.quantity
     }
@@ -31,14 +27,5 @@ class GeojsonReportSerializer < ActiveModel::Serializer
           object.latitude
         ]
       }
-  end
-
-  private
-
-  def photo_url
-    variant = object.tracer.photo.variant(resize: '100x100>').processed
-    Rails.application.routes.url_helpers.rails_blob_representation_path(
-      variant.blob.signed_id, variant.variation.key, variant.blob.filename, only_path: true
-    )
   end
 end

--- a/frontend/src/store/modules/tracers.js
+++ b/frontend/src/store/modules/tracers.js
@@ -29,7 +29,9 @@ const getters = {
   },
   getPerPage: state => {
     return state.perPage
-  }
+  },
+  getTracerById: state => tracerId =>
+    state.data.filter(tracer => tracerId === tracer.id)[0]
 }
 
 const mutations = {

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -10,6 +10,7 @@
 import { createNamespacedHelpers } from 'vuex'
 const { mapGetters, mapActions } = createNamespacedHelpers('reports')
 const addReportModule = createNamespacedHelpers('addReport')
+const tracersModule = createNamespacedHelpers('tracers')
 
 import AddReport from '@/components/AddReport'
 
@@ -253,7 +254,8 @@ export default {
       this.map.on('click', 'unclustered-reports', e => {
         let coordinates = e.features[0].geometry.coordinates.slice()
         let reportProperties = e.features[0].properties
-        let tracerProperties = JSON.parse(e.features[0].properties.tracer)
+        let tracerId = e.features[0].properties.tracer_id
+        let tracer = this.getTracerById()(tracerId)
         let userProperties = JSON.parse(e.features[0].properties.user)
 
         // Ensure that if the map is zoomed out such that multiple
@@ -269,15 +271,13 @@ export default {
             `<article class="media">
                 <div class="media-left">
                   <figure class="image is-64x64">
-                    <img src="${this.apiUrl}${
-              tracerProperties.photo
-            }" alt="Image">
+                    <img src="${this.apiUrl}${tracer.photo}" alt="Image">
                   </figure>
                 </div>
                 <div class="media-content">
                   <div class="content">
                     <p>
-                      <strong>${tracerProperties.name}</strong>
+                      <strong>${tracer.name}</strong>
                       <br>
                       <small>
                         ${userProperties.name}
@@ -312,6 +312,7 @@ export default {
     },
     destroyMap() {},
     ...mapGetters(['getReports', 'getLoading', 'getErrors']),
+    ...tracersModule.mapGetters(['getTracerById']),
     ...addReportModule.mapGetters([
       'getCurrentStep',
       'getAddress',

--- a/spec/serializers/geojson_report_serializer_spec.rb
+++ b/spec/serializers/geojson_report_serializer_spec.rb
@@ -10,10 +10,7 @@ describe GeojsonReportSerializer do
   it { expect(subject.serializable_hash[:properties]).to have_key(:reported_at) }
   it { expect(subject.serializable_hash[:properties]).to have_key(:user) }
   it { expect(subject.serializable_hash[:properties][:user]).to have_key(:name) }
-  it { expect(subject.serializable_hash[:properties]).to have_key(:tracer) }
-  it { expect(subject.serializable_hash[:properties][:tracer]).to have_key(:id) }
-  it { expect(subject.serializable_hash[:properties][:tracer]).to have_key(:name) }
-  it { expect(subject.serializable_hash[:properties][:tracer]).to have_key(:photo) }
+  it { expect(subject.serializable_hash[:properties]).to have_key(:tracer_id) }
   it { expect(subject.serializable_hash[:properties]).to have_key(:color) }
   it { expect(subject.serializable_hash[:properties]).to have_key(:quantity) }
   it { expect(subject.serializable_hash).to have_key(:geometry) }

--- a/spec/support/api/schemas/geojson-report.json
+++ b/spec/support/api/schemas/geojson-report.json
@@ -6,19 +6,11 @@
     "type": { "enum": ["Feature"] },
     "properties": {
       "type": "object",
-      "required": [
-        "user",
-        "reported_at",
-        "user",
-        "tracer",
-        "color",
-        "quantity"
-      ],
+      "required": ["user", "reported_at", "tracer_id", "color", "quantity"],
       "properties": {
         "id": {
           "type": "string",
-          "pattern":
-            "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
         },
         "reported_at": {
           "type": "string",
@@ -27,14 +19,9 @@
         "user": {
           "name": { "type": "string" }
         },
-        "tracer": {
-          "id": {
-            "type": "string",
-            "pattern":
-              "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
-          },
-          "name": { "type": "string" },
-          "photo": { "type": "string" }
+        "tracer_id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
         },
         "color": {
           "type": "string",


### PR DESCRIPTION
There is duplicate information between `reports`' geojson and `tracers` json. In order to slim geojson payload, we can get rid of it. It improves perf on back and front.

Before
```json
        {
            "type": "Feature",
            "properties": {
                "id": "5bf4459d-f403-4797-9940-640e5eafe1c3",
                "reported_at": "2018-03-10",
                "user": {
                    "name": "Name"
                },
                "tracer": {
                    "id": "66f91148-b104-48e9-ab20-36242396c145",
                    "name": "Seringue MacKesson",
                    "photo": "/rails/active_storage/representations/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaEpJaWt3T0dZMk1EUmpOaTA0TnpBNUxUUXlNMlF0WVdOa1l5MW1NVFkyTXpJME5qSTNZMlVHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6ImJsb2JfaWQifX0=--5f765a2dba3f53f3cb0bcf9aaed4cc899137214e/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaDdCam9MY21WemFYcGxTU0lOTVRBd2VERXdNRDRHT2daRlZBPT0iLCJleHAiOm51bGwsInB1ciI6InZhcmlhdGlvbiJ9fQ==--db0306ef231b7238fffa947c616824d35c5706be/b54ecf76.png"
                },
                "color": "#610422",
                "quantity": 3
            },
            "geometry": {
                "type": "Point",
                "coordinates": [
                    -3.52649331092835,
                    47.770288971056
                ]
            }
        }
```

After 
```json
   {
      "type": "Feature",
      "properties": {
        "id": "b6029a02-5122-441e-b1fa-3eeac5e7b93c",
        "reported_at": "2018-12-31",
        "user": { "name": "aaaaa" },
        "tracer_id": "e3a96231-9195-4bde-a959-7c0583581810",
        "color": "#12c672",
        "quantity": 1
      },
      "geometry": {
        "type": "Point",
        "coordinates": [-1.21948242186721, 48.3875033191446]
      }
    }
```