### PR TITLE
Disable cache service-worker, reload on new update

### DIFF
--- a/dockerfiles/nginx.conf
+++ b/dockerfiles/nginx.conf
@@ -29,6 +29,12 @@ server {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }
 
+  location ~* (service-worker\.js)$ {
+    add_header 'Cache-Control' 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
+    expires off;
+    proxy_no_cache 1;
+  }
+
   error_page 442 = @upstream;
   location = /reports {
     if ( $arg_user_id != "" ) {

--- a/frontend/src/registerServiceWorker.js
+++ b/frontend/src/registerServiceWorker.js
@@ -15,6 +15,7 @@ if (process.env.NODE_ENV === 'production') {
     },
     updated() {
       console.log('New content is available; please refresh.')
+      window.location.reload(true)
     },
     offline() {
       console.log(

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -6,5 +6,11 @@ module.exports = {
       localeDir: 'locales',
       enableInSFC: true
     }
+  },
+  pwa: {
+    workboxPluginMode: 'GenerateSW',
+    workboxOptions: {
+      skipWaiting: true
+    }
   }
 }


### PR DESCRIPTION
On alpha, app doesnt get the last changes even after refresh

This will force reload the app when a new version is available.

We can implement a refresh button in a notification in the future.