### PR TITLE
Add shore length to Reports

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -59,12 +59,12 @@ class ReportsController < ApiController
   end
 
   def report_params
-    params.permit(:tracer_id, :name, :quantity, :address, :longitude, :latitude,
+    params.permit(:tracer_id, :name, :quantity, :shore_length, :address, :longitude, :latitude,
                   :description, :reported_at)
   end
 
   def report_params_update
-    params.permit(:name, :quantity, :address, :longitude, :latitude,
+    params.permit(:name, :quantity, :shore_length, :address, :longitude, :latitude,
                   :description, :reported_at)
   end
 

--- a/app/models/concerns/report_manager.rb
+++ b/app/models/concerns/report_manager.rb
@@ -30,9 +30,11 @@ module Concerns
         list do
           sort_by :created_at
           field :status, :state do
-            column_width 99
+            column_width 50
           end
-          field :photo, :active_storage
+          field :photo, :active_storage do
+            column_width 100
+          end
           field :tracer do
             column_width 99
           end
@@ -40,7 +42,10 @@ module Concerns
             column_width 99
           end
           field :quantity do
-            column_width 75
+            column_width 50
+          end
+          field :shore_length do
+            column_width 50
           end
           field :description do
             column_width 99
@@ -75,6 +80,7 @@ module Concerns
           field :tracer
           field :name
           field :quantity
+          field :shore_length
           field :longitude
           field :latitude
           field :address
@@ -85,7 +91,7 @@ module Concerns
 
         state(
           events: { reject: 'btn-danger', accept: 'btn-success' },
-          states: { rejected: 'label-important', accepted: 'label-success' },
+          states: { rejected: 'label-danger', accepted: 'label-success' },
           disable: []
         )
       end

--- a/app/models/concerns/tracer_manager.rb
+++ b/app/models/concerns/tracer_manager.rb
@@ -10,17 +10,39 @@ module Concerns
       rails_admin do
         list do
           sort_by :created_at
-          field :name
-          field :description
-          field :photo, :active_storage
-          field :origin
-          field :kind
-          field :category
-          field :longitude
-          field :latitude
-          field :created_at
-          field :updated_at
-          field :color, :color
+          field :name do
+            column_width 66
+          end
+          field :description do
+            column_width 66
+          end
+          field :photo, :active_storage do
+            column_width 50
+          end
+          field :origin do
+            column_width 50
+          end
+          field :kind do
+            column_width 50
+          end
+          field :category do
+            column_width 50
+          end
+          field :longitude do
+            column_width 50
+          end
+          field :latitude do
+            column_width 50
+          end
+          field :created_at do
+            column_width 50
+          end
+          field :updated_at do
+            column_width 50
+          end
+          field :color, :color do
+            column_width 50
+          end
         end
 
         show do

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -2,19 +2,20 @@
 #
 # Table name: reports
 #
-#  id          :uuid             not null, primary key
-#  tracer_id   :uuid
-#  name        :string
-#  quantity    :integer
-#  address     :string
-#  longitude   :float
-#  latitude    :float
-#  description :text
-#  reported_at :date
-#  status      :string
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  user_id     :uuid
+#  id           :uuid             not null, primary key
+#  tracer_id    :uuid
+#  name         :string
+#  quantity     :integer
+#  address      :string
+#  longitude    :float
+#  latitude     :float
+#  description  :text
+#  reported_at  :date
+#  status       :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  user_id      :uuid
+#  shore_length :integer
 #
 # Indexes
 #
@@ -35,8 +36,10 @@ class Report < ApplicationRecord
   belongs_to :tracer
   belongs_to :user, optional: true
 
-  validates :tracer_id, :name, :latitude, :longitude, :reported_at, presence: true
+  validates :tracer_id, :name, :latitude, :longitude, :reported_at, :quantity, :shore_length, presence: true
   validates :photo, attached: true,
                     content_type: ['image/png', 'image/jpeg', 'image/tiff', 'image/webp'],
                     if: -> { !self.user&.senior && self.status != 'accepted' }
+  validates :shore_length, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 10 }
+  validates :quantity, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 500 }
 end

--- a/app/serializers/geojson_report_serializer.rb
+++ b/app/serializers/geojson_report_serializer.rb
@@ -15,7 +15,8 @@ class GeojsonReportSerializer < ActiveModel::Serializer
       },
       tracer_id: object.tracer_id,
       color: object.tracer.color,
-      quantity: object.quantity
+      quantity: object.quantity,
+      shore_length: object.shore_length
     }
   end
 

--- a/app/serializers/report_serializer.rb
+++ b/app/serializers/report_serializer.rb
@@ -1,6 +1,6 @@
 class ReportSerializer < ActiveModel::Serializer
   attributes :id, :name, :latitude, :longitude, :tracer, :reported_at, :tracer_id,
-             :quantity, :status, :address
+             :quantity, :shore_length, :status, :address
 
   def name
     object.user&.name || object.name

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -7,7 +7,7 @@ RailsAdmin.config do |config|
 
   ## == ActiveStorage ==
   # https://github.com/sferik/rails_admin/issues/3014
-  config.excluded_models = ['ActiveStorage::Blob', 'ActiveStorage::Attachment']
+  config.excluded_models = ['ActiveStorage::Blob', 'ActiveStorage::Attachment', 'AccessToken']
 
   ## == Devise ==
   config.authenticate_with do
@@ -35,9 +35,13 @@ RailsAdmin.config do |config|
     config.logging = true
   end
 
+config.model 'Admin' do
+  visible false
+end
+
   config.actions do
-    dashboard                     # mandatory
-    index                         # mandatory
+    dashboard # mandatory
+    index   # mandatory
     new
     export
     bulk_delete

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,7 @@ en:
         reported_at: Reported at
         tracer: Tracer
         quantity: Quantity
+        shore_length: Shore kilometers
         date: Date of report
         status: Status
       user:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -37,6 +37,7 @@ es:
         reported_at: Informado a
         tracer: Localizador
         quantity: Cantidad
+        shore_length: kilómetro costero
         date: Fecha del informe
         status: Status
       user:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -37,6 +37,7 @@ fr:
         reported_at: Signalé le
         tracer: Traceur
         quantity: Quantité
+        shore_length: Kilomètre de rivages
         date: Date du signalement
         status: Statut
       user:

--- a/db/migrate/20200126164840_add_shore_length_to_reports.rb
+++ b/db/migrate/20200126164840_add_shore_length_to_reports.rb
@@ -1,0 +1,5 @@
+class AddShoreLengthToReports < ActiveRecord::Migration[5.2]
+  def change
+    add_column :reports, :shore_length, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_26_083946) do
+ActiveRecord::Schema.define(version: 2020_01_26_164840) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -89,6 +89,7 @@ ActiveRecord::Schema.define(version: 2019_05_26_083946) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "user_id"
+    t.integer "shore_length"
     t.index ["address"], name: "index_reports_on_address"
     t.index ["latitude"], name: "index_reports_on_latitude"
     t.index ["longitude"], name: "index_reports_on_longitude"

--- a/frontend/.nvmrc
+++ b/frontend/.nvmrc
@@ -1,1 +1,1 @@
-lts/dubnium
+lts/erbium

--- a/frontend/src/components/TracerCard.vue
+++ b/frontend/src/components/TracerCard.vue
@@ -8,25 +8,29 @@
     </div>
     <div class="card-content">
       <div class="content">
-        <p class="title is-4">{{ tracer.name }}</p>
-        <p>{{ tracer.description }}</p>
+        <p class="title is-4">{{ tracer.name | capitalize }}</p>
+        <p>{{ tracer.description | capitalize }}</p>
         <p>
           <strong>{{ $t('origin') }}:</strong>
-          {{ tracer.origin }}
+          {{ tracer.origin | capitalize }}
         </p>
         <p>
           <strong>{{ $t('kind') }}:</strong>
-          {{ tracer.kind }}
+          {{ tracer.kind | capitalize }}
         </p>
         <p>
           <strong>{{ $t('created_at') }}:</strong>
           <time datetime="tracer.created_at | formatDate">
-            {{ tracer.created_at | formatDate }}
-          </time>
+            {{ tracer.created_at | formatDate }}</time
+          >
         </p>
         <p>
           <strong>{{ $t('quantity') }}:</strong>
           {{ getReportCount()(tracer.id) }}
+        </p>
+        <p>
+          <strong>{{ $t('quantity_by_km') }}:</strong>
+          {{ $n(getQuantitybyShoreLength()(tracer.id)) }}/km
         </p>
       </div>
     </div>
@@ -47,7 +51,7 @@ export default {
   },
   computed: {},
   methods: {
-    ...reportsModule.mapGetters(['getReportCount'])
+    ...reportsModule.mapGetters(['getReportCount', 'getQuantitybyShoreLength'])
   }
 }
 </script>
@@ -75,6 +79,7 @@ export default {
     "created_at": "Created at",
     "origin": "Origin",
     "quantity": "Reported quantity",
+    "quantity_by_km": "Quantity by km",
     "name": "Name",
     "kind": "Type"
   },
@@ -82,6 +87,7 @@ export default {
     "created_at": "Créé le",
     "origin": "Origine",
     "quantity": "Quantité signalée",
+    "quantity_by_km": "Quantité par km",
     "name": "Nom",
     "kind": "Type"
   },
@@ -89,6 +95,7 @@ export default {
     "created_at": "Creado en",
     "origin": "Origen",
     "quantity": "Cantidad testificada",
+    "quantity_by_km": "Cantidad por km",
     "name": "Apellido",
     "kind": "Tipo"
   }

--- a/frontend/src/components/TracersGrid.vue
+++ b/frontend/src/components/TracersGrid.vue
@@ -14,7 +14,7 @@
         }})
       </button>
     </div>
-    <div v-for="(category, idt) in getCategories()" :key="idt">
+    <div v-for="(category, idt) in getCategories()" :key="idt" class="tracers-grid-wrapper">
       <h2 class="category-title title is-2">{{ $t(category) }}</h2>
       <div class="tracers-grid columns is-multiline is-mobile">
         <div
@@ -169,6 +169,10 @@ export default {
 .tracers-grid {
   width: 100%;
   margin-bottom: 1rem;
+}
+
+.tracers-grid-wrapper {
+  margin-bottom: 1.75rem;
 }
 
 .category-title {

--- a/frontend/src/components/TracersGrid.vue
+++ b/frontend/src/components/TracersGrid.vue
@@ -72,6 +72,11 @@ export default {
           type: 'num',
           order: 'asc'
         },
+        shore_length: {
+          active: false,
+          type: 'num',
+          order: 'asc'
+        },
         created_at: {
           active: false,
           type: 'date',
@@ -92,7 +97,7 @@ export default {
   },
   methods: {
     ...mapGetters(['getTracers', 'getCategories']),
-    ...reportsModule.mapGetters(['getReportCount']),
+    ...reportsModule.mapGetters(['getReportCount', 'getQuantitybyShoreLength']),
     sortTracersBy: function(field, order) {
       if (order == null) {
         order = this.sortFields[field].order
@@ -121,6 +126,25 @@ export default {
           }
         })
       }
+
+      if (field === 'shore_length') {
+        this.sortedTracers.sort((a, b) => {
+          if (
+            this.getQuantitybyShoreLength()(a.id) <
+            this.getQuantitybyShoreLength()(b.id)
+          ) {
+            return 0 - modifier
+          } else if (
+            this.getQuantitybyShoreLength()(a.id) >
+            this.getQuantitybyShoreLength()(b.id)
+          ) {
+            return modifier
+          } else {
+            return 0
+          }
+        })
+      }
+
       this.sortedTracers.sort((a, b) => {
         if (a[field] < b[field]) {
           return 0 - modifier
@@ -161,6 +185,7 @@ export default {
     "created_at": "Created at",
     "origin": "Origin",
     "quantity": "Reported quantity",
+    "shore_length": "Quantity by km",
     "name": "Name",
     "research": "Research",
     "drift": "Drift",
@@ -175,6 +200,7 @@ export default {
     "created_at": "Créé le",
     "origin": "Origine",
     "quantity": "Quantité signalée",
+    "shore_length": "Quantité par km",
     "name": "Nom",
     "research": "Recherche",
     "drift": "Dérive",
@@ -189,6 +215,7 @@ export default {
     "created_at": "Creado en",
     "origin": "Origen",
     "quantity": "Cantidad testificada",
+    "shore_length": "Cantidad por km",
     "name": "Apellido",
     "research": "Búsqueda",
     "drift": "Dériva",

--- a/frontend/src/components/TracersList.vue
+++ b/frontend/src/components/TracersList.vue
@@ -22,24 +22,27 @@
       detail-key="id"
     >
       <template slot-scope="props">
-        <b-table-column field="name" v-bind:label="$t('name')" sortable>
-          {{ props.row.name }}
-        </b-table-column>
-        <b-table-column field="name" v-bind:label="$t('origin')" sortable>
-          {{ props.row.origin }}
-        </b-table-column>
-        <b-table-column field="kind" v-bind:label="$t('type')" sortable>
-          {{ props.row.kind }}
-        </b-table-column>
-        <b-table-column field="category" v-bind:label="$t('category')" sortable>
-          {{ $t(props.row.category) }}
-        </b-table-column>
+        <b-table-column field="name" v-bind:label="$t('name')" sortable>{{
+          props.row.name
+        }}</b-table-column>
+        <b-table-column field="name" v-bind:label="$t('origin')" sortable>{{
+          props.row.origin
+        }}</b-table-column>
+        <b-table-column field="kind" v-bind:label="$t('type')" sortable>{{
+          props.row.kind
+        }}</b-table-column>
+        <b-table-column
+          field="category"
+          v-bind:label="$t('category')"
+          sortable
+          >{{ $t(props.row.category) }}</b-table-column
+        >
         <b-table-column
           field="created_at"
           v-bind:label="$t('created_at')"
           sortable
-          >{{ props.row.created_at | formatDate }}
-        </b-table-column>
+          >{{ props.row.created_at | formatDate }}</b-table-column
+        >
         <b-table-column
           field="reported_quantity"
           v-bind:label="$t('reported_quantity')"
@@ -47,8 +50,17 @@
           width="100"
           centered
           :custom-sort="sortByReportedQuantity"
-          >{{ getReportCount()(props.row.id) }}
-        </b-table-column>
+          >{{ getReportCount()(props.row.id) }}</b-table-column
+        >
+        <b-table-column
+          field="quantity_by_km"
+          v-bind:label="$t('quantity_by_km')"
+          sortable
+          width="100"
+          centered
+          :custom-sort="sortByQuantityPerKm"
+          >{{ $n(getQuantitybyShoreLength()(props.row.id)) }}</b-table-column
+        >
       </template>
       <template slot="detail" slot-scope="props">
         <article class="media">
@@ -99,12 +111,20 @@ export default {
   methods: {
     ...mapMutations(['setPerPage']),
     ...mapGetters(['getPerPage']),
-    ...reportsModule.mapGetters(['getReportCount']),
+    ...reportsModule.mapGetters(['getReportCount', 'getQuantitybyShoreLength']),
     sortByReportedQuantity: function(tracerA, tracerB, isAsc) {
       const reportCountA = this.getReportCount()(tracerA.id)
       const reportCountB = this.getReportCount()(tracerB.id)
 
       return isAsc ? reportCountA - reportCountB : reportCountB - reportCountA
+    },
+    sortByQuantityPerKm: function(tracerA, tracerB, isAsc) {
+      const reportCountPerKmA = this.getQuantitybyShoreLength()(tracerA.id)
+      const reportCountPerKmB = this.getQuantitybyShoreLength()(tracerB.id)
+
+      return isAsc
+        ? reportCountPerKmA - reportCountPerKmB
+        : reportCountPerKmB - reportCountPerKmA
     }
   },
   computed: {
@@ -148,6 +168,7 @@ export default {
     "origin": "Origin",
     "per_page": "per page",
     "reported_quantity": "Reported quantity",
+    "quantity_by_km": "Quantity by km",
     "research": "Research",
     "drift": "Drift",
     "container": "Container",
@@ -162,6 +183,7 @@ export default {
     "origin": "Origine",
     "per_page": "par page",
     "reported_quantity": "Quantité signalée",
+    "quantity_by_km": "Quantité par km",
     "research": "Recherche",
     "drift": "Dérive",
     "container": "Conteneur",
@@ -176,6 +198,7 @@ export default {
     "origin": "Origen",
     "per_page": "por página",
     "reported_quantity": "Cantidad testificada",
+    "quantity_by_km": "Cantidad por km",
     "research": "Búsqueda",
     "drift": "Dériva",
     "container": "Envase",

--- a/frontend/src/components/tools/AddReport.vue
+++ b/frontend/src/components/tools/AddReport.vue
@@ -319,7 +319,7 @@
                       areSomeReportsSubmitted
                   "
                 >
-                  <b-icon icon="plus"></b-icon>
+                  {{ $t('add') }}
                 </a>
               </b-field>
               <b-message
@@ -964,6 +964,7 @@ export default {
 {
   "en": {
     "report_verb": "Report",
+    "add": "Add a tracer",
     "add_report": "Report a waste",
     "address": "Address",
     "cancel_report": "Close reporting",
@@ -998,6 +999,7 @@ export default {
   },
   "fr": {
     "report_verb": "Signaler",
+    "add": "Ajouter un traceur",
     "add_report": "Signaler un déchet",
     "address": "Adresse",
     "cancel_report": "Fermer l'ajout de signalement",
@@ -1032,6 +1034,7 @@ export default {
   },
   "es": {
     "report_verb": "Informe",
+    "add": "Añadir un trazador",
     "add_report": "Reportar un desperdicio",
     "address": "Dirección",
     "cancel_report": "Cerrar agrega testimonio",

--- a/frontend/src/components/tools/AddReport.vue
+++ b/frontend/src/components/tools/AddReport.vue
@@ -240,10 +240,43 @@
                       name="quantity"
                       type="number"
                       step="1"
-                      min="0"
-                      :data-vv-as="$t('quantity') | lowercase"
-                      v-validate="'required|min_value:0'"
+                      min="1"
+                      max="500"
+                      :data-vv-as="$t('quantity')"
+                      v-validate="'required|min_value:1|max_value:500'"
                     ></b-input>
+                  </b-field>
+                  <b-field
+                    :label="index === 0 ? ' ' : ''"
+                    class="shore-length-field"
+                    :type="errors.has('shoreLength') ? 'is-danger' : ''"
+                    :message="
+                      errors.has('shoreLength')
+                        ? errors.first('shoreLength')
+                        : ''
+                    "
+                  >
+                    <b-tooltip
+                      :label="$t('shore_length_tooltip')"
+                      position="is-left"
+                    >
+                      <div class="shore-length-unit-wrapper">
+                        <p class="shore-length-on">
+                          {{ $t('shore_length_on') }}
+                        </p>
+                        <b-input
+                          v-model="shoreLengths[index]"
+                          name="shoreLength"
+                          type="number"
+                          step="1"
+                          min="1"
+                          max="10"
+                          :data-vv-as="$t('shore_length')"
+                          v-validate="'required|min_value:1|max_value:10'"
+                        ></b-input>
+                        <p class="shore-length-unit">km</p>
+                      </div>
+                    </b-tooltip>
                   </b-field>
                   <b-field
                     :label="index === 0 ? '-' : ''"
@@ -369,6 +402,7 @@ export default {
       file: null,
       isSaved: [false],
       quantities: [1],
+      shoreLengths: [1],
       tracerNames: [''],
       username: this.$auth.check() ? this.$auth.user().name : '',
       description: '',
@@ -525,6 +559,7 @@ export default {
         reported_at: String(moment(this.reportDate).format('YYYY-MM-DD')),
         tracer_id: (this.selectedTracers[index] || {}).id,
         quantity: this.quantities[index],
+        shore_length: this.shoreLengths[index],
         description: this.description
       }
       if (file64 != null) postDataJson.photo = file64
@@ -565,6 +600,7 @@ export default {
       this.isSaved = [false]
       this.photo = ''
       this.quantities = [1]
+      this.shoreLengths = [1]
       this.reportDate = new Date()
       this.selectedTracers = [{}]
       this.tracerNames = ['']
@@ -584,6 +620,7 @@ export default {
       this.areSubmitted.splice(index, 1)
       this.areSubmitting.splice(index, 1)
       this.quantities.splice(index, 1)
+      this.shoreLengths.splice(index, 1)
       this.selectedTracers.splice(index, 1)
       this.tracerNames.splice(index, 1)
     },
@@ -598,6 +635,7 @@ export default {
       }
       this.selectedTracers.push({})
       this.quantities.push(1)
+      this.shoreLengths.push(1)
       this.tracerNames.push('')
       this.areSubmitting.push(false)
       this.areSubmitted.push(false)
@@ -800,7 +838,34 @@ export default {
 }
 
 .quantity-field {
-  width: 75px;
+  width: 66px;
+}
+
+.shore-length-field {
+  width: 100px;
+
+  .label {
+    height: 1.5rem;
+  }
+
+  .control,
+  input {
+    width: 50px;
+  }
+
+  .shore-length-unit-wrapper {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+  }
+
+  .shore-length-on {
+    margin-right: 10px;
+  }
+
+  .shore-length-unit {
+    margin-left: 5px;
+  }
 }
 </style>
 
@@ -839,7 +904,10 @@ export default {
   text-transform: capitalize;
 }
 
-/* Autocomplete */
+.autocomplete .dropdown-content {
+  width: 370px;
+}
+
 .autocomplete .dropdown-item {
   padding-right: 1rem;
 }
@@ -878,6 +946,18 @@ export default {
   margin-left: 0;
   padding-top: 0;
 }
+
+.shore-length-field label.label {
+  height: 1.5rem;
+}
+
+@media only screen and (max-device-width: 1024px) {
+.autocomplete .dropdown-content {
+  min-width: 240px;
+  width: auto;
+}
+
+}
 </style>
 
 <i18n>
@@ -899,6 +979,9 @@ export default {
     "optional": "optional",
     "previous": "Previous",
     "quantity": "Quantity",
+    "shore_length": "Shore kilometers",
+    "shore_length_on": "on",
+    "shore_length_tooltip": "Collection's kilometers of shore",
     "report_date": "Date of report",
     "report_review": "Thank you for your report. It will soon be reviewed by an administrator",
     "report": "Report",
@@ -930,6 +1013,9 @@ export default {
     "optional": "optionnel",
     "previous": "Précédent",
     "quantity": "Quantité",
+    "shore_length": "Kilomètres de rivage",
+    "shore_length_on": "sur",
+    "shore_length_tooltip": "Kilomètre de rivage du ramassage",
     "report_date": "Date de signalement",
     "report_review": "Merci pour votre signalement. Une validation va bientôt être effectuée.",
     "report": "Signalement",
@@ -961,6 +1047,9 @@ export default {
     "optional": "opcional",
     "previous": "Anterior",
     "quantity": "Cantidad",
+    "shore_length": "Kilómetros de la costa",
+    "shore_length_on": "en",
+    "shore_length_tooltip": "Recogida en la costa kilómetro",
     "report_date": "Fecha de reporte",
     "report_review": "Gracias por su testimonio. Uno administrador revisado soon",
     "report": "Testimonio",

--- a/frontend/src/components/tools/FilterReportsByDate.vue
+++ b/frontend/src/components/tools/FilterReportsByDate.vue
@@ -28,17 +28,10 @@
         >
           <span>{{ $t('this_month') }}</span>
         </button>
-        <button
-          class="button is-primary"
-          :class="{ 'is-active': isReportedAtEqualTo(startOfRange('year')) }"
-          @click="setReportedAt(startOfRange('year'))"
-        >
-          <span>{{ $t('this_year') }}</span>
-        </button>
       </div>
       <div class="buttons">
         <button
-          v-for="years in [3, 2, 1]"
+          v-for="years in [0, 1, 2, 3]"
           :key="years"
           class="button is-primary"
           :class="{
@@ -48,6 +41,8 @@
         >
           <span>{{ previousYearLabel(years) }}</span>
         </button>
+      </div>
+      <div class="buttons last">
         <button
           class="button is-primary"
           :class="{
@@ -224,8 +219,12 @@ export default {
   margin-bottom: 0.5em;
 }
 
-.buttons.first-row {
+.buttons {
   margin-bottom: 0;
+}
+
+.buttons.last {
+  margin-bottom: 1rem;
 }
 </style>
 
@@ -256,7 +255,6 @@ export default {
     "quick_selection": "Quick selection",
     "this_week": "Week to date",
     "this_month": "Month to date",
-    "this_year": "Year to date",
     "from_beginning": "From the beginning",
     "custom_range": "Custom range",
     "load_reports_failure": "Fail to load reports",
@@ -269,7 +267,6 @@ export default {
     "quick_selection": "Sélection rapide",
     "this_week": "Cette semaine",
     "this_month": "Ce mois",
-    "this_year": "Cette année",
     "from_beginning": "Depuis le début",
     "custom_range": "Période personnalisée",
     "load_reports_failure": "Échec de chargement des rapports",
@@ -282,7 +279,6 @@ export default {
     "quick_selection": "Selección rápida",
     "this_week": "Esta semana",
     "this_month": "Este mes",
-    "this_year": "Este año",
     "from_beginning": "Desde el principio",
     "custom_range": "Rango personalizado",
     "load_reports_failure": "Fallo al cargar informes",

--- a/frontend/src/store/modules/reports.js
+++ b/frontend/src/store/modules/reports.js
@@ -38,6 +38,13 @@ const getters = {
       return tracerId === report.properties.tracer_id
         ? (total += report.properties.quantity)
         : total
+    }, 0),
+  getQuantitybyShoreLength: state => tracerId =>
+    (state.reports.features || []).reduce((total, report) => {
+      return tracerId === report.properties.tracer_id
+        ? (total +=
+            report.properties.quantity / (report.properties.shore_length || 1))
+        : total
     }, 0)
 }
 const mutations = {

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -202,9 +202,14 @@ export default {
                     <h5 class="title is-5"><b>${tracer.name}</b></h5>
                     <p>
                       ${reportProperties.quantity}${' '}
-                      ${this.$i18n.tc('object', reportProperties.quantity)}
+                      ${this.$i18n.tc(
+                        'tracers',
+                        reportProperties.quantity
+                      )} ${this.$i18n.t('on')} ${
+            reportProperties.shore_length
+          } km
                     </p>
-                    <p>${this.$i18n.t('by')} ${userProperties.name}</p>
+                    <p>${this.$i18n.t('per')} ${userProperties.name}</p>
                     <p>${this.$options.filters.formatDate(
                       reportProperties.reported_at
                     )}</p>
@@ -312,7 +317,12 @@ export default {
           .addControl(geocoder, 'top-left')
           .addControl(geolocator)
           .addControl(navigater, 'bottom-right')
-          .on('load', () => resolve('done'))
+          .on('load', () => {
+            document
+              .querySelector('.mapboxgl-ctrl-geocoder--input')
+              .addEventListener('focus', this.closeToolbar, false)
+            resolve('done')
+          })
       })
     },
     mapLoad: async function() {
@@ -471,6 +481,7 @@ export default {
       'getLoading',
       'getErrors'
     ]),
+    ...toolBarModule.mapActions(['closeToolbar']),
     removeSourceAndLayer: function(map, id) {
       if (map.getLayer(id) != null) map.removeLayer(id)
       if (map.getSource(id) != null) map.removeSource(id)
@@ -842,24 +853,27 @@ export default {
 <i18n>
 {
   "en": {
-    "object": "item | items",
+    "tracers": "tracer | tracers",
     "search_location": "Find a place",
     "no_address_found": "No address found",
-    "by": "By",
+    "per": "per",
+    "on": "on",
     "map_init_failure": "Error initializing map"
   },
   "fr": {
-    "object": "exemplaire | exemplaires",
+    "tracers": "traceur | traceurs",
     "search_location": "Rechercher un endroit",
     "no_address_found": "Pas d'adresse trouvée",
-    "by": "Par",
+    "per": "par",
+    "on": "sur",
     "map_init_failure": "Échec d'initialisation de la carte"
   },
   "es": {
-    "object": "objeto | objetos",
+    "tracers": "trazador | trazadores",
     "search_location": "Encontrar un lugar",
     "no_address_found": "No se encontró dirección",
-    "by": "pro",
+    "per": "pro",
+    "on": "más de",
     "map_init_failure": "Error al inicializar el mapa"
   }
 }

--- a/frontend/src/views/MyReports.vue
+++ b/frontend/src/views/MyReports.vue
@@ -12,12 +12,7 @@
         </b-select>
 
         <div class="control is-flex">
-          <input
-            class="input"
-            v-model="filter"
-            type="search"
-            v-bind:placeholder="$t('search')"
-          />
+          <input class="input" v-model="filter" type="search" v-bind:placeholder="$t('search')" />
         </div>
       </b-field>
 
@@ -37,8 +32,7 @@
             v-bind:label="$t('tracer')"
             width="40"
             sortable
-            >{{ props.row.tracer }}</b-table-column
-          >
+          >{{ props.row.tracer }}</b-table-column>
 
           <b-table-column
             field="quantity"
@@ -46,8 +40,15 @@
             sortable
             centered
             width="20"
-            >{{ props.row.quantity }}</b-table-column
-          >
+          >{{ props.row.quantity }}</b-table-column>
+
+          <b-table-column
+            field="shore_length"
+            v-bind:label="$t('shore_length')"
+            sortable
+            centered
+            width="20"
+          >{{ props.row.shore_length }}</b-table-column>
 
           <b-table-column
             field="reported_at"
@@ -55,24 +56,21 @@
             sortable
             centered
             width="125"
-            >{{ props.row.reported_at | formatDate }}</b-table-column
-          >
+          >{{ props.row.reported_at | formatDate }}</b-table-column>
 
           <b-table-column
             field="address"
             v-bind:label="$t('address')"
             sortable
             centered
-            >{{ props.row.address }}</b-table-column
-          >
+          >{{ props.row.address }}</b-table-column>
 
           <b-table-column
             field="status"
             v-bind:label="$t('status')"
             sortable
             centered
-            >{{ props.row.status | capitalize }}</b-table-column
-          >
+          >{{ props.row.status | capitalize }}</b-table-column>
         </template>
       </b-table>
     </div>
@@ -136,6 +134,7 @@ export default {
     "address": "Address",
     "reported_at": "Reported at",
     "quantity": "Quantity",
+    "shore_length": "Shore kilometers",
     "per_page": "per page",
     "search": "Search"
   },
@@ -147,6 +146,7 @@ export default {
     "reported_at": "Témoigné le",
     "name": "Nom",
     "quantity": "Quantité",
+    "shore_length": "Kilomètre de rivage",
     "per_page": "par page",
     "search": "Rechercher"
   },
@@ -158,6 +158,7 @@ export default {
     "reported_at": "Reportado en",
     "name": "Apellido",
     "quantity": "Cantidad",
+    "shore_length": "Costa kilómetro",
     "per_page": "por página",
     "search": "Buscar"
   }

--- a/frontend/src/views/Tracers.vue
+++ b/frontend/src/views/Tracers.vue
@@ -82,6 +82,8 @@ const {
   mapGetters,
   mapActions
 } = createNamespacedHelpers('tracers')
+const reportsModule = createNamespacedHelpers('reports')
+
 import TracersGrid from '@/components/TracersGrid'
 import TracersList from '@/components/TracersList'
 
@@ -96,7 +98,12 @@ export default {
       searchKeywords: ''
     }
   },
-  async created() {},
+  async created() {
+    await this.loadReports({
+      reported_at_min: this.$reported_at_min,
+      reported_at_max: this.$reported_at_max
+    })
+  },
   methods: {
     getFilteredTracers() {
       if (this.$normalizeStr(this.searchKeywords) !== '') {
@@ -111,7 +118,8 @@ export default {
     },
     ...mapGetters(['getTracers', 'getLoading']),
     ...mapMutations(['setDisplayFormat']),
-    ...mapActions(['loadTracers'])
+    ...mapActions(['loadTracers']),
+    ...reportsModule.mapActions(['loadReports'])
   },
   computed: {
     ...mapState({

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2480,11 +2480,6 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-bowser@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.6.1.tgz#196599588af6f0413449c79ab3bf7a5a1bb3384f"
-  integrity sha512-hySGUuLhi0KetfxPZpuJOsjM0kRvCiCgPBygBkzGzJNsq/nbJmaO8QJc6xlWfeFFnMvtd/LeKkhDJGVrmVobUA==
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"

--- a/lib/tasks/populate_shore_length.rake
+++ b/lib/tasks/populate_shore_length.rake
@@ -1,0 +1,13 @@
+namespace :db do
+  desc 'Populate shore length'
+  task populate_shore_length: :environment do
+    for report in Report.all
+      if report.shore_length.nil?
+        report.update_attributes!(shore_length: 1)
+        puts "Updated report #{report.id} with shore_length of 1"
+      else
+        puts 'Nothing to do on this report'
+      end
+    end
+  end
+end

--- a/spec/factories/report.rb
+++ b/spec/factories/report.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
 
     name { Faker::Name.name }
     quantity { Random.new.rand(42)+1 }
+    shore_length { Random.new.rand(9)+1 }
     longitude { Random.new.rand(42) }
     latitude { Random.new.rand(42) }
     description { Faker::Lorem.sentence }

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -4,6 +4,7 @@ describe Report do
   it { expect(subject).to have_db_column(:id) }
   it { expect(subject).to have_db_column(:name) }
   it { expect(subject).to have_db_column(:quantity) }
+  it { expect(subject).to have_db_column(:shore_length) }
   it { expect(subject).to have_db_column(:address) }
   it { expect(subject).to have_db_column(:longitude) }
   it { expect(subject).to have_db_column(:latitude) }

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -76,7 +76,8 @@ describe 'ApiController', type: :request do
       {
         name: 'toto',
         quantity: 42,
-        missing: 'required params',
+        shore_length: 7,
+        missing: 'required params'
       }
     end
     let(:request) do
@@ -99,6 +100,7 @@ describe 'ApiController', type: :request do
       {
         name: 'toto',
         quantity: 42,
+        shore_length: 7,
         address: 'somewhere',
         longitude: 42,
         latitude: 42.42,

--- a/spec/requests/reports_spec.rb
+++ b/spec/requests/reports_spec.rb
@@ -170,6 +170,7 @@ describe 'ReportsController', type: :request do
       {
         name: 'toto',
         quantity: 42,
+        shore_length: 7,
         address: 'somewhere',
         longitude: 42,
         latitude: 42.42,
@@ -268,6 +269,7 @@ describe 'ReportsController', type: :request do
       {
         name: 'toto',
         quantity: 42,
+        shore_length: 7,
         address: 'somewhere',
         longitude: 42,
         latitude: 42.42,
@@ -286,6 +288,7 @@ describe 'ReportsController', type: :request do
       model = Report.find(report.id)
       expect(model.name).to eq(parameters[:name])
       expect(model.quantity).to eq(parameters[:quantity])
+      expect(model.shore_length).to eq(parameters[:shore_length])
       expect(model.address).to eq(parameters[:address])
       expect(model.longitude).to eq(parameters[:longitude])
       expect(model.latitude).to eq(parameters[:latitude])

--- a/spec/serializers/geojson_report_serializer_spec.rb
+++ b/spec/serializers/geojson_report_serializer_spec.rb
@@ -13,6 +13,7 @@ describe GeojsonReportSerializer do
   it { expect(subject.serializable_hash[:properties]).to have_key(:tracer_id) }
   it { expect(subject.serializable_hash[:properties]).to have_key(:color) }
   it { expect(subject.serializable_hash[:properties]).to have_key(:quantity) }
+  it { expect(subject.serializable_hash[:properties]).to have_key(:shore_length) }
   it { expect(subject.serializable_hash).to have_key(:geometry) }
   it { expect(subject.serializable_hash[:geometry]).to have_key(:type) }
   it { expect(subject.serializable_hash[:geometry]).to have_key(:coordinates) }

--- a/spec/serializers/report_serializer_spec.rb
+++ b/spec/serializers/report_serializer_spec.rb
@@ -12,5 +12,6 @@ describe ReportSerializer do
   it { expect(subject.serializable_hash).to have_key(:reported_at) }
   it { expect(subject.serializable_hash).to have_key(:tracer_id) }
   it { expect(subject.serializable_hash).to have_key(:quantity) }
+  it { expect(subject.serializable_hash).to have_key(:shore_length) }
   it { expect(subject.serializable_hash).to have_key(:status) }
 end

--- a/spec/support/api/schemas/geojson-report.json
+++ b/spec/support/api/schemas/geojson-report.json
@@ -6,7 +6,14 @@
     "type": { "enum": ["Feature"] },
     "properties": {
       "type": "object",
-      "required": ["user", "reported_at", "tracer_id", "color", "quantity"],
+      "required": [
+        "user",
+        "reported_at",
+        "tracer_id",
+        "color",
+        "quantity",
+        "shore_length"
+      ],
       "properties": {
         "id": {
           "type": "string",
@@ -27,7 +34,8 @@
           "type": "string",
           "pattern": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"
         },
-        "quantity": { "type": "integer" }
+        "quantity": { "type": "integer" },
+        "shore_length": { "type": "integer", "minimum": 0, "maximum": 10 }
       }
     },
     "geometry": {

--- a/spec/support/api/schemas/report.json
+++ b/spec/support/api/schemas/report.json
@@ -1,16 +1,34 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "required": ["id", "name", "latitude", "longitude", "tracer", "reported_at", "tracer_id", "quantity", "status"],
+  "required": [
+    "id",
+    "name",
+    "latitude",
+    "longitude",
+    "tracer",
+    "reported_at",
+    "tracer_id",
+    "quantity",
+    "shore_length",
+    "status"
+  ],
   "properties": {
-    "id": { "type": "string", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$" },
+    "id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    },
     "name": { "type": "string" },
     "latitude": { "type": "number" },
     "longitude": { "type": "number" },
     "tracer": { "type": "string" },
     "reported_at": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
-    "tracer_id": { "type": "string", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$" },
+    "tracer_id": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+    },
     "quantity": { "type": "integer" },
+    "shore_length": { "type": "integer", "minimum": 0, "maximum": 10 },
     "address": { "type": "string" },
     "status": { "type": "string" }
   },


### PR DESCRIPTION
## Add shore length to Reports

Todo:
Margin tracer list title
[+] add report => add tracer


The goal is to get an idea of the frequency of a tracer on the shore.
It can then used to get statistics (in France we can find 1 waste every X km)

## Front
Add quantity by kilometers on map popup, add report and myreports
Add total quantity by kilometers in tracer list/grid
Add quantity min max (>=1;<=500) in add report
Add wider dropdown for tracer selection in add report
Fix missing information when directly going on `/tracers/`. It loads reports on this view now.
Set Node to current LTS (12/erbium)
Small ui fixes


## Back
Add `shore_lenght` attribute to `Report`  (>=1;<=10)
Add rake task to populate `shore length`
Add quantity presence validation and min max (>=1;<=500)

## Back office
Hide admin list
Disable access token
Adjust column heights
Fix rejected label css class